### PR TITLE
Docs: Add links to other available Py Compilers

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -2,3 +2,26 @@
 
 LPython is an ahead-of-time compiler for Python, built using the Abstract Semantic Representation (ASR) technology. Part of the
 [LCompilers](https://lcompilers.org) collection.
+
+Links to other available Python compilers:
+
+* https://cython.org/
+* https://pythran.readthedocs.io/en/latest/
+* https://numba.pydata.org/
+* https://transonic.readthedocs.io/en/latest/index.html
+* https://seq-lang.org/
+* https://pytorch.org/
+* https://github.com/google/jax
+* https://www.weld.rs/
+* https://cupy.dev/
+* https://github.com/pyccel/pyccel
+* https://github.com/Quansight-Labs/uarray
+* https://doc.pypy.org/en/latest/
+* https://nuitka.net/
+* https://github.com/pyston/pyston
+* https://github.com/jakeret/hope
+* https://github.com/shedskin/shedskin
+* https://github.com/google/grumpy
+* https://www.jython.org/
+* https://ironpython.net/
+* http://pyjs.org/


### PR DESCRIPTION
Fixes https://github.com/lcompilers/lpython/issues/6.