### PR TITLE
Remove repeated line in the blog

### DIFF
--- a/content/blog/lpython_mvp.md
+++ b/content/blog/lpython_mvp.md
@@ -107,7 +107,7 @@ Note that time lpython `/Users/czgdp1807/lpython_project/debug.py --backend=c` i
 
 ### Just-In-Time Compilation
 
-Just-in-time compilation in LPython requires only decorating Python function with `@lpython`. The decorator takes an option for specifying the desired backend, as in, `@lpython(backend="c")` or `@lpython(backend="llvm")`. Only C is supported at present; LLVM and others will be added in the near future. The decorator also propagates backend-specific options. For example
+Just-in-time compilation in LPython requires only decorating Python function with `@lpython`. The decorator takes an option for specifying the desired backend, as in, `@lpython(backend="c")` or `@lpython(backend="llvm")`. The decorator also propagates backend-specific options. For example
 
 ```python
 @lpython(backend="c",


### PR DESCRIPTION
This is also mentioned here: https://github.com/lcompilers/lpython.org-deploy/blob/95ea00e26e1e0095013d3b5647686015aa238cd4/content/blog/lpython_mvp.md?plain=1#L701. 
So, I removed it!