### PR TITLE
Add link to dev.lpython.org

### DIFF
--- a/content/index_intro/index.md
+++ b/content/index_intro/index.md
@@ -16,4 +16,6 @@ Main repository at GitHub:
 [https://github.com/lcompilers/lpython](https://github.com/lcompilers/lpython)
 {{< github_lpython_button >}}
 
+Try LPython in your browser using WebAssembly: https://dev.lpython.org/
+
 Any questions? Ask us on Zulip [![project chat](https://img.shields.io/badge/zulip-join_chat-brightgreen.svg)](https://lfortran.zulipchat.com/#narrow/stream/311866-LPython).


### PR DESCRIPTION
It looks as follows in the browser:

<img width="878" alt="Screenshot 2023-09-24 at 12 49 00 AM" src="https://github.com/lcompilers/lpython.org-deploy/assets/43722035/3dafe3fc-48eb-4852-92f5-a9249ca4dd0f">
